### PR TITLE
Enlistment lock

### DIFF
--- a/ethereum/contracts/EnlistmentToContract.sol
+++ b/ethereum/contracts/EnlistmentToContract.sol
@@ -97,6 +97,11 @@ contract EnlistmentToContract {
         require(tenantAgreementMap[tenantEmail].status == status);
         _;
     }
+
+    modifier notLocked() {
+        require(!locked);
+        _;
+    }
     
     
     modifier maintainerOnly() {
@@ -121,6 +126,7 @@ contract EnlistmentToContract {
     // what if the offer is in status PENDING and the tenant wants to send a new one?
     function sendOffer(int amount, string tenantName, string tenantEmail) payable public
     noActiveOffer(tenantEmail)
+    notLocked()
         {
         var offer = Offer({
             initialized: true,

--- a/ethereum/contracts/EnlistmentToContract.sol
+++ b/ethereum/contracts/EnlistmentToContract.sol
@@ -8,6 +8,7 @@ contract EnlistmentToContract {
     
     address owner;
     string public landlord;
+    bool public locked = false;
     Enlistment public enlistment;
     mapping(string => Offer) tenantOfferMap;
     mapping(string => AgreementDraft) tenantAgreementMap;
@@ -215,6 +216,7 @@ contract EnlistmentToContract {
         {
             tenantAgreementMap[tenantEmail].landlordSignedHash = landlordSignedHash;
             tenantAgreementMap[tenantEmail].status = AgreementStatus.LANDLORD_SIGNED;
+            locked = true;
             var agreement = tenantAgreementMap[tenantEmail];
             var typed = AgreementDraft(agreement.landlordName, agreement.tenantName,
                 agreement.tenantEmail, agreement.amount, agreement.leaseStart, agreement.handoverDate,

--- a/ethereum/contracts/EnlistmentToContract.sol
+++ b/ethereum/contracts/EnlistmentToContract.sol
@@ -216,6 +216,7 @@ contract EnlistmentToContract {
     
 
     function landlordSignAgreement(string tenantEmail, string landlordSignedHash) payable public
+        notLocked()
         offerExists(tenantEmail)
         offerInStatus(OfferStatus.ACCEPTED, tenantEmail)
         agreementInStatus(AgreementStatus.CONFIRMED, tenantEmail)

--- a/ethereum/test/enlistment_to_contract.js
+++ b/ethereum/test/enlistment_to_contract.js
@@ -288,6 +288,11 @@ contract('EnlistmentToContract', async ([owner]) => {
         assert.isTrue(isLocked);
       });
 
+      it('should lock the enlistment for new offers after the landlord signs', async() => {
+        await instance.landlordSignAgreement('cassian@reply.xd', 'l4ndl0rdSignedDraftPDFH4sh');
+        await expectThrowMessage(instance.sendOffer(800, 'Gianna', 'gianna@never-reply.xd'), expectThrowMessage);
+      });
+
       it('should sign the contract: tenant', async() => {
         await instance.landlordSignAgreement('cassian@reply.xd', 'l4ndl0rdSignedDraftPDFH4sh');
         await instance.tenantSignAgreement('cassian@reply.xd', 't3n4ntSignedDraftPDFH4sh');

--- a/ethereum/test/enlistment_to_contract.js
+++ b/ethereum/test/enlistment_to_contract.js
@@ -290,7 +290,7 @@ contract('EnlistmentToContract', async ([owner]) => {
 
       it('should lock the enlistment for new offers after the landlord signs', async() => {
         await instance.landlordSignAgreement('cassian@reply.xd', 'l4ndl0rdSignedDraftPDFH4sh');
-        await expectThrowMessage(instance.sendOffer(800, 'Gianna', 'gianna@never-reply.xd'), expectThrowMessage);
+        await expectThrowMessage(instance.sendOffer(800, 'Gianna', 'gianna@never-reply.xd'), revertErrorMsg);
       });
 
       it('should sign the contract: tenant', async() => {

--- a/ethereum/test/enlistment_to_contract.js
+++ b/ethereum/test/enlistment_to_contract.js
@@ -305,6 +305,20 @@ contract('EnlistmentToContract', async ([owner]) => {
         await expectThrowMessage(instance.landlordSignAgreement('morry@reply.xd', 'secondHash'));
       });
 
+      it('unlocks upon offer cancellation', async () => {
+        await instance.landlordSignAgreement('cassian@reply.xd', 'l4ndl0rdSignedDraftPDFH4sh');
+        await instance.cancelOffer('cassian@reply.xd');
+        const isLocked = await instance.locked.call();
+        assert.isFalse(isLocked);
+      });
+
+      it('unlocks upon agreement cancellation', async () => {
+        await instance.landlordSignAgreement('cassian@reply.xd', 'l4ndl0rdSignedDraftPDFH4sh');
+        await instance.cancelAgreement('cassian@reply.xd');
+        const isLocked = await instance.locked.call();
+        assert.isFalse(isLocked);
+      });
+
       it('should sign the contract: tenant', async() => {
         await instance.landlordSignAgreement('cassian@reply.xd', 'l4ndl0rdSignedDraftPDFH4sh');
         await instance.tenantSignAgreement('cassian@reply.xd', 't3n4ntSignedDraftPDFH4sh');

--- a/ethereum/test/enlistment_to_contract.js
+++ b/ethereum/test/enlistment_to_contract.js
@@ -277,6 +277,12 @@ contract('EnlistmentToContract', async ([owner]) => {
         assert.equal(agreementHashes[1], 'l4ndl0rdSignedDraftPDFH4sh');
       });
 
+      it('should set the locked property to "true" after the landlord signs', async() => {
+        await instance.landlordSignAgreement('cassian@reply.xd', 'l4ndl0rdSignedDraftPDFH4sh');
+        const isLocked = await instance.locked.call();
+        assert.isTrue(isLocked);
+      });
+
       it('should sign the contract: tenant', async() => {
         await instance.landlordSignAgreement('cassian@reply.xd', 'l4ndl0rdSignedDraftPDFH4sh');
         await instance.tenantSignAgreement('cassian@reply.xd', 't3n4ntSignedDraftPDFH4sh');
@@ -287,6 +293,7 @@ contract('EnlistmentToContract', async ([owner]) => {
         const agreementHashes = await instance.getAgreementHashes('cassian@reply.xd');
         assert.equal(agreementHashes[2], 't3n4ntSignedDraftPDFH4sh');
       });
+
     });
 
     describe('Collecting the first month rent', async () => {

--- a/ethereum/test/enlistment_to_contract.js
+++ b/ethereum/test/enlistment_to_contract.js
@@ -47,6 +47,11 @@ contract('EnlistmentToContract', async ([owner]) => {
       assert.equal(landlord, 'landlord@email.xd');
     });
 
+    it('should set locked property to false', async() => {
+      let isLocked = await contract.locked.call();
+      assert.isFalse(isLocked);
+    })
+
     it('should instanciate the enlistment', async () => {
       let enlistment = await contract.enlistment.call(); // returns an array which represents an enlistment struct
       assert.equal(enlistment[0], 'Waker');

--- a/ethereum/test/enlistment_to_contract.js
+++ b/ethereum/test/enlistment_to_contract.js
@@ -293,6 +293,18 @@ contract('EnlistmentToContract', async ([owner]) => {
         await expectThrowMessage(instance.sendOffer(800, 'Gianna', 'gianna@never-reply.xd'), revertErrorMsg);
       });
 
+      it('should block signing of any other agreement until the enlistment is locked', async() => {
+        await instance.sendOffer(5000, 'Moriarty', 'morry@reply.xd');
+
+        await instance.landlordSignAgreement('cassian@reply.xd', 'l4ndl0rdSignedDraftPDFH4sh');
+
+        await instance.reviewOffer(true, 'morry@reply.xd');
+        await instance.submitDraft('morry@reply.xd', 'John Wick', 'Cassian', 'morry@reply.xd', 12, 15, 65, 'No cats', 'H4sh');
+        await instance.reviewAgreement('morry@reply.xd', true);
+
+        await expectThrowMessage(instance.landlordSignAgreement('morry@reply.xd', 'secondHash'));
+      });
+
       it('should sign the contract: tenant', async() => {
         await instance.landlordSignAgreement('cassian@reply.xd', 'l4ndl0rdSignedDraftPDFH4sh');
         await instance.tenantSignAgreement('cassian@reply.xd', 't3n4ntSignedDraftPDFH4sh');


### PR DESCRIPTION
- As an incentive measurement to move the rental process along as quickly as possible, the enlistment locks from new offers after the landlord signs the agreement.
- Smart contract does not allow landlord to sign multiple tenancy agreements for one enlistment.
- Enlistment unlocks upon offer or agreement cancellation.
- Flow fully tested.
